### PR TITLE
Handle null main branch

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func handleIssueComment(gh *GithubClient, ic *IssueCommentWebhook) error {
 func handleCheckSuite(gh *GithubClient, cs *CheckSuiteWebhook) error {
 	fmt.Println("Handling check suite event.")
 
-	if cs.CheckSuite.HeadBranch == "main" {
+	if cs.CheckSuite.HeadBranch == "main" || cs.CheckSuite.HeadBranch == "" {
 		fmt.Println("Skipping check suite for main branch.")
 		return nil
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -167,6 +167,8 @@ func TestCheckSuite(t *testing.T) {
 			true, CommitStateSuccess, payloads.CheckSuiteEvent},
 		{"skip for main branch", singleAppTarget, CheckSuiteConclusionSuccess, "", false, zeroCommitState,
 			[]byte(strings.ReplaceAll(string(payloads.CheckSuiteEvent), `"head_branch": "changes"`, `"head_branch": "main"`))},
+		{"skip for main branch null", singleAppTarget, CheckSuiteConclusionSuccess, "", false, zeroCommitState,
+			[]byte(strings.ReplaceAll(string(payloads.CheckSuiteEvent), `"head_branch": "changes"`, `"head_branch": null`))},
 	} {
 		var postedStatus bool
 		var postedState CommitState


### PR DESCRIPTION
I'm not 100% sure about this, but it seems some commits to main have a `null` main branch value, which is causing check enforcer to evaluate the commit checks instead of skipping them. For example: https://github.com/Azure/azure-sdk-for-net/actions/runs/3805218416/jobs/6472999750

This updates the main branch skip logic to skip null branch values for `head_branch`. I don't think this should be merged until we can verify that this value is only null for commits to main.