### PR TITLE
Skip processing check suite statuses on unsupported events

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -146,7 +146,8 @@ func TestCheckSuite(t *testing.T) {
 	assert.NoError(err)
 	var zeroCommitState CommitState
 	singleAppTarget := []string{"octocoders-linter"}
-	multiAppTarget := []string{"Octocat App", "Hexacat App"}
+	multiAppTargetExcludeEvent := []string{"Octocat App", "Hexacat App"}
+	multiAppTarget := []string{"octocoders-linter", "Octocat App", "Hexacat App"}
 	noMatchAppTarget := []string{"no-match"}
 	servers := []*httptest.Server{}
 
@@ -157,6 +158,8 @@ func TestCheckSuite(t *testing.T) {
 			[]byte(strings.ReplaceAll(string(payloads.CheckSuiteEvent), `"conclusion": "success"`, fmt.Sprintf("\"conclusion\": \"%s\"", CommitStateFailure)))},
 		{"POST success for single suite", singleAppTarget, "", "", true, CommitStateSuccess, payloads.CheckSuiteEvent},
 		{"POST pending for no match, single suite", noMatchAppTarget, "", "", true, CommitStatePending, payloads.CheckSuiteEvent},
+		{"POST pending for no match, multiple suite", multiAppTargetExcludeEvent, CheckSuiteConclusionSuccess, CheckSuiteConclusionSuccess,
+			true, CommitStatePending, payloads.CheckSuiteEvent},
 		{"POST pending for multiple suites pending", multiAppTarget, CheckSuiteConclusionSuccess, CheckSuiteConclusionEmpty,
 			true, CommitStatePending, payloads.CheckSuiteEvent},
 		{"POST pending for multiple suites pending 2", multiAppTarget, CheckSuiteConclusionEmpty, CheckSuiteConclusionSuccess,


### PR DESCRIPTION
This fixes a check suite evaluation timing issue where:

1. An unsupported app posts a check suite event (e.g. Microsoft Github Policy Service)
2. Github Actions events also post check suite statuses, but the Github Actions are from our Github Event Processor, which needs to run on the `pull_request_target` event but is not actually a CI gate.
3. Check enforcer queries check suites and gets a list of passing check suites > 0. Since we support Github Actions as an app target, check enforcer posts a success status.
4. We should still be pending because no Azure Pipelines based CI gates have actually posted a status by the time steps 1-3 complete, so they are not evaluated at the time of the check suites API call.

The fix involves us skipping check suite evaluation for any events from unsupported apps. This means we will only evaluate check suite data when we actually receive a check suite update from an app we care about. The one exception is events from pull_request_target Github Actions not used as CI gates, but since we also need to explicitly allow workflows to trigger other workflows on a per-workflow basis via `workflow_dispatch`, any actions we do not care about as CI checks will not trigger processing too early.