### PR TITLE
Write github event payload with cat to fix too large env values

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,10 @@ runs:
   steps:
     - run: |
         cd $GITHUB_ACTION_PATH
-        echo "$GITHUB_PAYLOAD" > ./github_payload.json
+        cat > ./github_payload.json << 'EOF'
+        ${{ toJson(github.event) }}
+        EOF
         go run . ./github_payload.json
       shell: bash
       env:
-        GITHUB_PAYLOAD: ${{ toJson(github.event) }}
         GITHUB_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
When a PR comment is especially large, it breaks how we write the payload file from the shell environment, because the value exceeds the max environment variable size and/or command line size. Instead we can inject the value directly into the inline shell script (using a multi-line statement with cat), which will allow for much larger, or arbitrarily large, values.