### PR TITLE
Reduce check enforcer logging

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,7 @@ runs:
   steps:
     - run: |
         cd $GITHUB_ACTION_PATH
-        cat > ./github_payload.json << 'EOF'
-        ${{ toJson(github.event) }}
-        EOF
-        go run . ./github_payload.json
+        go run . $GITHUB_EVENT_PATH
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,14 @@ runs:
   steps:
     - run: |
         cd $GITHUB_ACTION_PATH
-        go run . $GITHUB_EVENT_PATH
+        go run . ${{ github.event_path }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
+
+    - name: Archive github event data
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: event
+        path: ${{ github.event_path }}

--- a/github_client.go
+++ b/github_client.go
@@ -186,14 +186,14 @@ func (gh *GithubClient) request(req *http.Request) ([]byte, error) {
 
 	defer resp.Body.Close()
 	fmt.Println("Received", resp.Status)
-	fmt.Println("Response:")
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return []byte{}, err
 	}
-	fmt.Println(fmt.Sprintf("%s", data))
 
 	if resp.StatusCode >= 400 {
+		fmt.Println("Error Response:")
+		fmt.Println(fmt.Sprintf("%s", data))
 		return []byte{}, errors.New(fmt.Sprintf("Received http error %d", resp.StatusCode))
 	}
 

--- a/main.go
+++ b/main.go
@@ -215,7 +215,6 @@ func handleCheckSuite(gh *GithubClient, cs *CheckSuiteWebhook) error {
 		return nil
 	}
 
-
 	eventIsFromSupportedApp := false
 	for _, app := range gh.AppTargets {
 		if app == cs.CheckSuite.App.Name {


### PR DESCRIPTION
Reduce check enforcer logging

FYI @mikeharder I didn't know until now that you can grab the webhook payload from disk (thanks to @hallipr). This saves us a lot of log storage space, as before I was putting the whole payload inline to the bash command (to work around env var max size issues).